### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ To install via vscode without building from source, see: https://silq.ethz.ch/in
 
 Silq is written in the D programming language. D compilers are available at http://dlang.org/download.html.
 
+### FreeBSD
+
+Silq can be built from a port or installed as a binary package on FreeBSD/amd64. 
+Other FreeBSD platforms do currently lack the D language support required by silq.
+
+To install from source, assuming an up-to-date ports tree is available:
+```
+$ cd /usr/ports/lang/silq
+$ make install
+```
+(Or use portmaster or any of the other ports management tools available in FreeBSD ...)
+
+To install from a package:
+```
+$ pkg install silq
+```
+
 ### Other platforms
 
 The build instructions given here are for GNU/Linux and OSX. Silq can also be built on other platforms.


### PR DESCRIPTION
I have created and committed a FreeBSD "port" of silq on 2020-06-18.

Binary packages for amd64 are automatically built and distributed to package mirrors within a few days whenever the port is updated in the FreeBSD ports repository.
The port is maintained and updated by me - I'm checking the eth-sri/silq repository for significant updates (and receive repo mails e.g. regarding pull requests).

I'd appreciate if there were tags for "stable" versions of silq (and perhaps matching tags for utils and ast) to refer to in Github check-outs, but for now I'm using git hashes to refer to the respective revisions to be used in the FreeBSD port or package and add the date of the last git commit as a substitute of a revision number.

I'm currently waiting for the merge of Shor's algorithm and will then update the FreeBSD port to that revision ...